### PR TITLE
refactor: rename clientId to userId

### DIFF
--- a/backend/openapi/spec.yml
+++ b/backend/openapi/spec.yml
@@ -118,7 +118,7 @@ components:
           type: string
         courtId:
           type: string
-        clientId:
+        userId:
           type: string
         startTime:
           type: string

--- a/backend/src/modules/reservations/reservation.types.ts
+++ b/backend/src/modules/reservations/reservation.types.ts
@@ -1,7 +1,7 @@
 export interface Reservation {
     id: string;
     courtId: string;
-    clientId: string;
+    userId: string;
     startTime: Date;
     endTime: Date;
     date: Date;
@@ -11,7 +11,7 @@ export interface Reservation {
 
 export interface CreateReservationInput {
     courtId: string;
-    clientId: string;
+    userId: string;
     startTime: Date;
     endTime: Date;
     date: Date;
@@ -21,7 +21,7 @@ export interface CreateReservationInput {
 export interface UpdateReservationInput {
     id: string;
     courtId?: string;
-    clientId?: string;
+    userId?: string;
     startTime?: Date;
     endTime?: Date;
     date?: Date;

--- a/backend/src/tests/reservations.test.ts
+++ b/backend/src/tests/reservations.test.ts
@@ -19,7 +19,7 @@ describe('Reservations API', () => {
       .post('/api/reservations')
       .send({
         courtId: 'court123',
-        clientId: 'client123',
+        userId: 'user123',
         startTime: new Date().toISOString(),
         endTime: new Date(new Date().getTime() + 60 * 60 * 1000).toISOString(),
       });

--- a/frontend/src/types/billing.ts
+++ b/frontend/src/types/billing.ts
@@ -1,6 +1,6 @@
 export interface Invoice {
     id: string;
-    clientId: string;
+    userId: string;
     amount: number;
     date: Date;
     status: 'paid' | 'pending' | 'canceled';

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -3,7 +3,7 @@
 export interface Reservation {
     id: string;
     courtId: string;
-    clientId: string;
+    userId: string;
     startTime: Date;
     endTime: Date;
     status: 'confirmed' | 'canceled' | 'pending';

--- a/frontend/src/types/reservation.ts
+++ b/frontend/src/types/reservation.ts
@@ -1,7 +1,7 @@
 export interface Reservation {
     id: string;
     courtId: string;
-    clientId: string;
+    userId: string;
     startTime: Date;
     endTime: Date;
     sportType: 'football' | 'tennis' | 'paddle' | 'other';


### PR DESCRIPTION
## Summary
- replace `clientId` with `userId` in reservation types, OpenAPI spec, and tests
- align frontend types (reservation, billing, index) with new `userId` field

## Testing
- `npm test` *(fails: ReferenceError: module is not defined in ES module scope)*
- `npm run build` *(fails: TS1005 '>' expected in frontend/src/config/routes.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689f5dfeb9e08327ba5da883048f4859