### PR TITLE
docs: remove trailing fragment from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,4 @@ Contributions are welcome! Please submit a pull request or open an issue for any
 
 ## Acknowledgments
 
-Thank you to all contributors and libraries that made this project possible.# sportware
+Thank you to all contributors and libraries that made this project possible.


### PR DESCRIPTION
## Summary
- remove stray `# sportware` fragment from README and ensure newline at end of file

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f5ddefc108327bd0892d688ed665e