### PR TITLE
Add minimal FastAPI server for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+__pycache__
+*.pyc

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ SportWare is a comprehensive management system designed for the efficient handli
    npm run dev
    ```
 
+   Alternatively, a minimal FastAPI server is available for quick testing:
+   ```
+   pip install -r requirements.txt
+   uvicorn server.main:app --reload
+   ```
+
 5. Start the frontend application:
    ```
    cd frontend

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.110.0
+uvicorn[standard]==0.29.0

--- a/server/main.py
+++ b/server/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+async def read_root():
+    return {"message": "SportWare backend running"}


### PR DESCRIPTION
## Summary
- provide basic FastAPI app so `uvicorn server.main:app --reload` runs
- add Python dependencies list
- document how to start the FastAPI server
- ignore Python cache files

## Testing
- `npm test` *(fails: Module has no default export...)*
- `python -m py_compile server/main.py`


------
https://chatgpt.com/codex/tasks/task_e_689f64b1fd00832781f75571cf42d140